### PR TITLE
feat: Add build-release job to create release artifacts

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -16,6 +16,7 @@ env:
   GORELEASER_VERSION: '~> v2'
 
 jobs:
+
   # Parallel Code Quality Checks
   code-quality:
     name: 🧐 Code Quality
@@ -72,6 +73,7 @@ jobs:
   # Parallel Build Job
   build:
     name: 🏗️ Build CLI
+    needs: [code-quality]
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -98,10 +100,42 @@ jobs:
         cd cli
         go build -o aws-taggy
 
+  # Build Release Artifacts
+  build-release:
+    name: 🏗️ Build Release
+    needs: [code-quality]
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📥 Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: ⚙️ Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: false
+
+      - name: 📦 Get Dependencies
+        run: |
+          go mod tidy
+          go mod download
+
+      - name: 🚀 Run GoReleaser Snapshot
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: ${{ env.GORELEASER_VERSION }}
+          args: release --snapshot --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+
   # Testing and Validation Job
   test-and-validate:
     name: 🧪 Tests & Release
-    needs: [build]
+    needs: [build, build-release]
     runs-on: ubuntu-latest
     steps:
     - name: 📥 Checkout Code
@@ -132,19 +166,10 @@ jobs:
       run: |
         ./cli/aws-taggy --help
 
-    - name: 🚀 Run GoReleaser Snapshot
-      uses: goreleaser/goreleaser-action@v6
-      with:
-        distribution: goreleaser
-        version: ${{ env.GORELEASER_VERSION }}
-        args: release --snapshot --clean
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   # Final Status Check
   pr-validation:
     name: ✅ PR Validation
-    needs: [code-quality, build, test-and-validate]
+    needs: [code-quality, build, test-and-validate, build-release]
     runs-on: ubuntu-latest
     if: always()
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,4 +59,5 @@ jobs:
         version: latest
         args: release --clean
       env:
-        GITHUB_TOKEN: ${{secrets.GH_HOMEBREW_TOKEN}}
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        GH_HOMEBREW_TOKEN: ${{secrets.GH_HOMEBREW_TOKEN}}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -57,7 +57,7 @@ brews:
       owner: Excoriate
       name: homebrew-tap
       branch: main
-      token: ${{ secrets.GH_HOMEBREW_TOKEN }}
+      token: ${{ Env.GH_HOMEBREW_TOKEN }}
     url_template: https://github.com/Excoriate/aws-taggy/releases/download/{{ .Tag }}/{{ .ArtifactName }}
     commit_author:
       name: Alex Torres

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ AWS Taggy solves these challenges by:
 Using [Homebrew](https://brew.sh/):
 
 ```bash
-brew tap excoriate/tap
+brew tap Excoriate/aws-taggy
 brew install aws-taggy
 ```
 


### PR DESCRIPTION
## 🏷️ AWS Taggy PR

### What Changes

- 📝 Adds a new "build-release" job to the PR CI workflow that runs the GoReleaser tool to create release artifacts, such as binaries and packages.
- 🔍 The new job ensures that the release artifacts are generated as part of the PR CI workflow, making them available for testing and validation before the final release.

### Why These Changes

- 💡 The motivation behind these changes is to streamline the release process by generating the necessary artifacts as part of the PR validation workflow.
- 🛡️ This enhancement to the tag management process ensures that the release artifacts are thoroughly tested and validated before they are made available for the final release.

### Testing

- [ ] Unit tests added/updated
- [ ] Tested with multiple AWS resource types
- [ ] Verified tag key/value validation
- [ ] Performance benchmarks (if applicable)

### Checklist

- [ ] Follows project coding standards
- [ ] Updated documentation
- [ ] Added/updated tests
- [ ] Considered multi-account scenarios

### Additional Context

- 🔗 Related issues
- 📸 Screenshots (if applicable)