### PR TITLE
fix: Update Homebrew token in .goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -57,7 +57,7 @@ brews:
       owner: Excoriate
       name: homebrew-tap
       branch: main
-      token: ${{ Env.GH_HOMEBREW_TOKEN }}
+      token: ${{ .Env.GH_HOMEBREW_TOKEN }}
     url_template: https://github.com/Excoriate/aws-taggy/releases/download/{{ .Tag }}/{{ .ArtifactName }}
     commit_author:
       name: Alex Torres


### PR DESCRIPTION
The changes in this commit update the Homebrew token in the `.goreleaser.yml` file. The token was previously using the `Env` syntax, which is incorrect. The correct syntax is `{{ .Env.GH_HOMEBREW_TOKEN }}`.

## 🏷️ AWS Taggy PR

### What Changes

- 📝 Brief description of changes
- 🔍 Specific AWS tag compliance improvements

### Why These Changes

- 💡 Motivation behind the changes
- 🛡️ How this enhances tag management

### Testing

- [ ] Unit tests added/updated
- [ ] Tested with multiple AWS resource types
- [ ] Verified tag key/value validation
- [ ] Performance benchmarks (if applicable)

### Checklist

- [ ] Follows project coding standards
- [ ] Updated documentation
- [ ] Added/updated tests
- [ ] Considered multi-account scenarios

### Additional Context

- 🔗 Related issues
- 📸 Screenshots (if applicable)
